### PR TITLE
[fix] remove sacdinput from mint functions

### DIFF
--- a/src/core/actions/mintVehicleWithDeviceDefinition.ts
+++ b/src/core/actions/mintVehicleWithDeviceDefinition.ts
@@ -23,7 +23,7 @@ export function mintVehicleCallData(
   return encodeFunctionData({
     abi: contracts[ContractType.DIMO_REGISTRY].abi,
     functionName: MINT_VEHICLE_WITH_DEVICE_DEFINITION,
-    args: [args.manufacturerNode, args.owner, args.deviceDefinitionID, args.attributeInfo, args.sacdInput],
+    args: [args.manufacturerNode, args.owner, args.deviceDefinitionID, args.attributeInfo],
   });
 }
 
@@ -40,7 +40,7 @@ export const mintVehicleWithDeviceDefinition = async (
       data: encodeFunctionData({
         abi: contracts[ContractType.DIMO_REGISTRY].abi,
         functionName: MINT_VEHICLE_WITH_DEVICE_DEFINITION,
-        args: [args.manufacturerNode, args.owner, args.deviceDefinitionID, args.attributeInfo, args.sacdInput],
+        args: [args.manufacturerNode, args.owner, args.deviceDefinitionID, args.attributeInfo],
       }),
     },
   ]);
@@ -59,7 +59,7 @@ export const mintVehicleWithDeviceDefinitionBatch = async (
       data: encodeFunctionData({
         abi: contracts[ContractType.DIMO_REGISTRY].abi,
         functionName: MINT_VEHICLE_WITH_DEVICE_DEFINITION,
-        args: [arg.manufacturerNode, arg.owner, arg.deviceDefinitionID, arg.attributeInfo, arg.sacdInput],
+        args: [arg.manufacturerNode, arg.owner, arg.deviceDefinitionID, arg.attributeInfo],
       }),
     };
   });
@@ -79,7 +79,7 @@ export const mintVehicleWithDeviceDefinitionFromAccount = async (
     address: contracts[ContractType.DIMO_REGISTRY].address,
     abi: contracts[ContractType.DIMO_REGISTRY].abi,
     functionName: MINT_VEHICLE_WITH_DEVICE_DEFINITION,
-    args: [args.manufacturerNode, args.owner, args.deviceDefinitionID, args.attributeInfo, args.sacdInput],
+    args: [args.manufacturerNode, args.owner, args.deviceDefinitionID, args.attributeInfo],
     account: walletClient.account,
   });
 

--- a/src/core/types/args.ts
+++ b/src/core/types/args.ts
@@ -4,8 +4,7 @@ export type MintVehicleWithDeviceDefinition = {
   manufacturerNode: BigInt;
   owner: `0x${string}`;
   deviceDefinitionID: string;
-  attributeInfo: { attribute: string; info: string }[];
-  sacdInput: { grantee: `0x${string}`; permissions: BigInt; expiration: BigInt; source: string };
+  attributeInfo: { attribute: string; info: string }[];  
 };
 
 export type VehiclePermissionDescription = {


### PR DESCRIPTION
This pull request updates the minting logic for vehicles with device definitions by removing the `sacdInput` argument from all relevant functions and types. This change simplifies the function signatures and updates the corresponding type definitions to reflect the removal.

### Minting function updates

* Removed the `sacdInput` argument from the `mintVehicleCallData`, `mintVehicleWithDeviceDefinition`, `mintVehicleWithDeviceDefinitionBatch`, and `mintVehicleWithDeviceDefinitionFromAccount` functions, ensuring all calls to `MINT_VEHICLE_WITH_DEVICE_DEFINITION` now omit this parameter. [[1]](diffhunk://#diff-850cb373b3840737c95c9d94249920277b25d2eae4108526fcf986dcad718a76L26-R26) [[2]](diffhunk://#diff-850cb373b3840737c95c9d94249920277b25d2eae4108526fcf986dcad718a76L43-R43) [[3]](diffhunk://#diff-850cb373b3840737c95c9d94249920277b25d2eae4108526fcf986dcad718a76L62-R62) [[4]](diffhunk://#diff-850cb373b3840737c95c9d94249920277b25d2eae4108526fcf986dcad718a76L82-R82)

### Type definition update

* Removed the `sacdInput` field from the `MintVehicleWithDeviceDefinition` type in `args.ts`, ensuring the type matches the updated function signatures.