### PR TITLE
feat(kernel-signer): add setAccountPermissions method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dimo-network/transactions",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "DIMO Transactions SDK",
   "keywords": [
     "DIMO",

--- a/src/KernelSigner.ts
+++ b/src/KernelSigner.ts
@@ -35,6 +35,10 @@ import {
   renounceAccountPermissions,
   renounceAccountPermissionsBatch,
 } from ":core/actions/renounceAccountPermissionsSACD.js";
+import {
+  setAccountPermissions,
+  setAccountPermissionsBatch,
+} from ":core/actions/setAccountPermissionsSACD.js";
 import { CHAIN_ABI_MAPPING, ENV_MAPPING, ENV_NETWORK_MAPPING, ENV_TO_API_MAPPING } from ":core/constants/mappings.js";
 import {
   AddStake,
@@ -52,6 +56,7 @@ import {
   RenounceVehiclePermissions,
   RenounceVehiclePermissionsBulk,
   SendDIMOTokens,
+  SetAccountPermissions,
   SetVehiclePermissions,
   SetVehiclePermissionsBulk,
   TransactionInput,
@@ -669,6 +674,36 @@ export class KernelSigner {
     }
     const client = await this.getActiveClient();
     const callData = await renounceVehiclePermissionsBulk(args, client, this.config.environment);
+
+    const userOpHash = await this._sendUserOperation(client, callData);
+
+    if (waitForReceipt) {
+      const client = await this.getActiveClient();
+      return await client.waitForUserOperationReceipt({
+        hash: userOpHash as `0x${string}`,
+      });
+    }
+
+    return {
+      userOperationHash: userOpHash,
+      status: "pending",
+    } as TransactionReturnType;
+  }
+
+  public async setAccountPermissions(
+    args: SetAccountPermissions | SetAccountPermissions[],
+    waitForReceipt: boolean = true,
+  ): Promise<TransactionReturnType> {
+    const client = await this.getActiveClient();
+    let callData: `0x${string}`;
+    if (!Array.isArray(args)) {
+      callData = await setAccountPermissions(args, client, this.config.environment);
+    } else {
+      if (args.length >= 25) {
+        throw Error("Batch account permission limit: 25");
+      }
+      callData = await setAccountPermissionsBatch(args, client, this.config.environment);
+    }
 
     const userOpHash = await this._sendUserOperation(client, callData);
 


### PR DESCRIPTION
## What

`KernelSigner` exposes `renounceAccountPermissions` but not its setter counterpart — the standalone `setAccountPermissions` / `setAccountPermissionsBatch` actions only encode calldata, so consumers had to hand-roll `sendUserOperation` + receipt wait (the DIMO Driver app currently does exactly that for account-level SACD grants).

Adds `KernelSigner.setAccountPermissions(args, waitForReceipt = true)` mirroring the existing `renounceAccountPermissions` pattern: single or array args, 25-item batch cap, optional receipt wait.

## Verification

- `npm run build` (tsc + tsc-alias) clean; `dist/KernelSigner.d.ts` exports the method
- `vitest` — 9/9 passing

## Consumer

dimo-driver's account-level document grant (`useAccountSharing`, DIMO-Network/dimo-driver#3203) can drop its manual calldata + sendUserOperation block once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)